### PR TITLE
Primal & dual bounds of objective

### DIFF
--- a/src/BlockDecomposition.jl
+++ b/src/BlockDecomposition.jl
@@ -9,7 +9,7 @@ const MOIU = MOI.Utilities
 const JC = JuMP.Containers
 
 export BlockModel, annotation, specify!, gettree, getmaster, getsubproblems,
-       indice, assignsolver!
+       indice, assignsolver!, objectiveprimalbound!, objectivedualbound!
 
 export @axis, @dantzig_wolfe_decomposition, @benders_decomposition
 
@@ -18,6 +18,7 @@ include("annotations.jl")
 include("tree.jl")
 include("formulations.jl")
 include("decomposition.jl")
+include("objective.jl")
 
 function BlockModel(args...; kw...)
     m = JuMP.Model(args...; kw...)

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -1,0 +1,27 @@
+struct ObjectivePrimalBound <: MOI.AbstractModelAttribute end
+struct ObjectiveDualBound <: MOI.AbstractModelAttribute end
+
+objectiveprimalbound!(model, value::Real) = MOI.set(model, ObjectivePrimalBound(), value)
+objectivedualbound!(model, value::Real) = MOI.set(model, ObjectiveDualBound(), value)
+
+function MOI.set(
+    dest::MOIU.UniversalFallback, attribute::ObjectivePrimalBound, value
+)
+    dest.modattr[attribute] = value
+    return
+end
+
+function MOI.set(
+    dest::MOIU.UniversalFallback, attribute::ObjectiveDualBound, value
+)
+    dest.modattr[attribute] = value
+    return
+end
+
+function MOI.get(dest::MOIU.UniversalFallback, attribute::ObjectivePrimalBound)
+    return get(dest.modattr, attribute, nothing)
+end
+
+function MOI.get(dest::MOIU.UniversalFallback, attribute::ObjectiveDualBound)
+    return get(dest.modattr, attribute, nothing)
+end

--- a/test/dantzigwolfe.jl
+++ b/test/dantzigwolfe.jl
@@ -184,5 +184,17 @@ function test_dummy_model_decompositions()
         test_annotation(x2_ann, BD.DwPricingSp, BD.DantzigWolfe, 1, 1)
         @test BD.getid(x1_ann) != BD.getid(x2_ann)
     end
+
+    @testset "Model with objective bounds" begin
+        model, y, z, fix, cov, knp, dec = dummymodel1()
+        BD.objectiveprimalbound!(model, 1234.0)
+        try 
+            JuMP.optimize!(model)
+        catch e
+            @test e isa NoOptimizer
+        end
+        @test MOI.get(model, BD.ObjectivePrimalBound()) == 1234.0
+        @test MOI.get(model, BD.ObjectiveDualBound()) === nothing
+    end
     return
 end


### PR DESCRIPTION
Introducing two new methods `objectiveprimalbound!` and `objectivedualbound!`.
It will help to define the initial cost of artificial variables.