### PR TITLE
Soft branching priorities

### DIFF
--- a/src/branchingpriority.jl
+++ b/src/branchingpriority.jl
@@ -1,16 +1,35 @@
 struct VarBranchingPriority <: MOI.AbstractVariableAttribute end
 
-branchingpriority!(model, x::JuMP.VariableRef, branching_priority::Int) = MOI.set(
-    model, VarBranchingPriority(), x, branching_priority
-)
+"""
+    branchingpriority!(x, value::Float64)
 
-branchingpriority(model, x::JuMP.VariableRef) = MOI.get(model, VarBranchingPriority(), x)
+Set the branching priority of variable `x` to `value`.
+
+You can use fractional branching priorities. 
+The idea is to have both "soft" and "hard" branching priorities. For instance :
+- if the number of branching candidates with priority 4.0 is less than the maximum number of candidates considered, no branching candidates with priority 3.0 will be considered
+- if the number of branching candidates with priority 3.5 is less than the maximum number of candidates considered, then some branching candidates with priority 3.0 will be considered (to bring the total number to the maximum)
+- if the number of branching candidates with priority 3.5 is not less than the maximum number, then no branching candidates with priority 3.0 will be considered
+"""
+branchingpriority!(x::JuMP.VariableRef, priority) = MOI.set(
+    x.model, VarBranchingPriority(), x, priority
+)
+@deprecate branchingpriority!(model, x::JuMP.VariableRef, priority) branchingpriority!(x, priority)
+
+"""
+    branchingpriority(x)
+
+Return the branching priority of variable `x`.
+"""
+branchingpriority(x::JuMP.VariableRef) = MOI.get(x.model, VarBranchingPriority(), x)
+@deprecate branchingpriority(model, x::JuMP.VariableRef) branchingpriority(x)
 
 function MOI.set(
     dest::MOIU.UniversalFallback, attribute::VarBranchingPriority, vi::MOI.VariableIndex, value
 )
     if !haskey(dest.varattr, attribute)
-        dest.varattr[attribute] = Dict{MOI.VariableIndex, Tuple}()
+        println("blabla")
+        dest.varattr[attribute] = Dict{MOI.VariableIndex, Float64}()
     end
     dest.varattr[attribute][vi] = value
     return
@@ -18,6 +37,6 @@ end
 
 function MOI.get(dest::MOIU.UniversalFallback, attribute::VarBranchingPriority, vi::MOI.VariableIndex)
     varattr = get(dest.varattr, attribute, nothing)
-    varattr === nothing && return 1
-    return get(varattr, vi, 1)
+    varattr === nothing && return 1.0
+    return get(varattr, vi, 1.0)
 end

--- a/src/branchingpriority.jl
+++ b/src/branchingpriority.jl
@@ -28,7 +28,6 @@ function MOI.set(
     dest::MOIU.UniversalFallback, attribute::VarBranchingPriority, vi::MOI.VariableIndex, value
 )
     if !haskey(dest.varattr, attribute)
-        println("blabla")
         dest.varattr[attribute] = Dict{MOI.VariableIndex, Float64}()
     end
     dest.varattr[attribute][vi] = value

--- a/test/branchingpriority.jl
+++ b/test/branchingpriority.jl
@@ -6,38 +6,39 @@ function test_branching_priority()
     @variable(model, w[i in 1:10, j in 1:i])
     
     @testset "Branching priority of a single variable" begin
-        @test BD.branchingpriority(model, x) == 1
-        BD.branchingpriority!(model, x, 2)
-        @test BD.branchingpriority(model, x) == 2
+        @test BD.branchingpriority(x) == 1.0
+        BD.branchingpriority!(x, 2.0)
+        @test BD.branchingpriority(x) == 2.0
     end
 
     @testset "Branching priority of a collection of variables" begin
-        for v in BD.branchingpriority.(model, y)
-            @test v == 1
+        for v in BD.branchingpriority.(y)
+            @test v == 1.0
         end
-        BD.branchingpriority!.(model, y, 2)
-        for v in BD.branchingpriority.(model, y)
-            @test v == 2
+        BD.branchingpriority!.(y, 2.0)
+        for v in BD.branchingpriority.(y)
+            @test v == 2.0
         end
     end
 
     @testset "Branching priority of a dense axis array of variables" begin
-        for v in BD.branchingpriority.(model, z)
-            @test v == 1
+        for v in BD.branchingpriority.(z)
+            @test v == 1.0
         end
-        BD.branchingpriority!.(model, z, 2)
-        for v in BD.branchingpriority.(model, z)
-            @test v == 2
+        BD.branchingpriority!.(z, 2.0)
+        for v in BD.branchingpriority.(z)
+            @test v == 2.0
         end
     end
 
     @testset "Branching priority of a sparse axis array of variables" begin
-        for v in BD.branchingpriority.(model, w)
-            @test v == 1
+        for v in BD.branchingpriority.(w)
+            @test v == 1.0
         end
-        BD.branchingpriority!.(model, w, 2)
-        for v in BD.branchingpriority.(model, w)
-            @test v == 2
+        BD.branchingpriority!.(w, 2.5)
+        for v in BD.branchingpriority.(w)
+            @test v == 2.5
         end
     end
+    return
 end


### PR DESCRIPTION
Following discussion in https://github.com/atoptima/Coluna.jl/pull/528 (ping @rrsadykov)

@laradicp I forgot to tell you that we can access model from `VariableRef`. I deprecated the methods with model as first arg.