### PR TITLE
subproblem representative variables

### DIFF
--- a/src/BlockDecomposition.jl
+++ b/src/BlockDecomposition.jl
@@ -16,7 +16,7 @@ const JC = JuMP.Containers
 
 export BlockModel, annotation, specify!, gettree, getmaster, getsubproblems, ×, indice,
        objectiveprimalbound!, objectivedualbound!, branchingpriority!, branchingpriority,
-       customvars!, customconstrs!, customvars, customconstrs
+       customvars!, customconstrs!, customvars, customconstrs, subproblemrepresentative
 export @axis, @dantzig_wolfe_decomposition, @benders_decomposition
 export AutoDwStrategy
 
@@ -24,6 +24,7 @@ include("axis.jl")
 include("annotations.jl")
 include("tree.jl")
 include("formulations.jl")
+include("subproblem_representative.jl")
 include("checker.jl")
 include("decomposition.jl")
 include("objective.jl")

--- a/src/branchingpriority.jl
+++ b/src/branchingpriority.jl
@@ -36,6 +36,6 @@ end
 
 function MOI.get(dest::MOIU.UniversalFallback, attribute::VarBranchingPriority, vi::MOI.VariableIndex)
     varattr = get(dest.varattr, attribute, nothing)
-    varattr === nothing && return 1.0
+    isnothing(varattr) && return 1.0
     return get(varattr, vi, 1.0)
 end

--- a/src/subproblem_representative.jl
+++ b/src/subproblem_representative.jl
@@ -1,0 +1,36 @@
+struct ListOfRepresentatives <: MOI.AbstractModelAttribute end
+struct RepresentativeVar <: MOI.AbstractVariableAttribute end
+
+"""
+    subproblemrepresentative(x, [subproblem1, subproblem2])
+
+Indicate that variable `x` will belongs to many subproblem (`subproblem1` and `subproblem2`
+in the example).
+
+Variable `x` should not contain any axis id in this indices otherwise BlockDecomposition
+will throw a [RepresentativeAlreadyInDwSp](@ref) error.
+"""
+function subproblemrepresentative(x::JuMP.VariableRef, subproblems::Vector{SubproblemForm})
+    @assert x.model == subproblems[1].model
+    MOI.set(x.model, RepresentativeVar(), x, getfield.(subproblems, :annotation))
+    return nothing
+end
+
+function MOI.set(
+    dest::MOIU.UniversalFallback, attribute::RepresentativeVar, vi::MOI.VariableIndex, sp_annotations
+)
+    if !haskey(dest.varattr, attribute)
+        dest.varattr[attribute] = Dict{MOI.VariableIndex,Vector{Annotation}}()
+    end
+    dest.varattr[attribute][vi] = sp_annotations
+    return
+end
+
+function MOI.get(dest::MOIU.UniversalFallback, attribute::RepresentativeVar, vi::MOI.VariableIndex)
+    varattr = get(dest.varattr, attribute, nothing)
+    isnothing(varattr) && return nothing
+    return get(varattr, vi, nothing)
+end
+
+MOI.get(dest::MOIU.UniversalFallback, ::ListOfRepresentatives) =
+    get(dest.varattr, RepresentativeVar(), nothing)

--- a/test/dantzigwolfe.jl
+++ b/test/dantzigwolfe.jl
@@ -237,5 +237,21 @@ function test_dummy_model_decompositions()
     @testset "Decomposition over an array" begin
         @test_throws BlockDecomposition.DecompositionNotOverAxis{UnitRange{Int64}} dummymodel4()
     end
+
+    @testset "Decomposition with representatives" begin
+        d = CvrpToyData()
+        model, x, cov, dummy_sp, mast, sps, dec = cvrp_with_representatives(d)
+        try
+            JuMP.optimize!(model)
+        catch e
+            @test e isa NoOptimizer
+        end
+    
+        x_annotation = BD.annotation(model, x[(1,2)])
+        @test x_annotation == getfield.(sps, :annotation)
+
+        dummy_sp_annotation = BD.annotation(model, dummy_sp[1])
+        test_annotation(dummy_sp_annotation, BD.DwPricingSp, BD.DantzigWolfe, 0, 10)
+    end
     return
 end

--- a/test/errors.jl
+++ b/test/errors.jl
@@ -5,6 +5,8 @@ function test_errors()
     vars_of_same_sp_in_master2()
     vars_of_same_sp_in_master3()
     decomposition_not_on_axis()
+    not_representative_of_sp()
+    different_dw_sp_vars_in_same_dw_sp()
 end
 
 function master_var_in_subproblem()
@@ -101,5 +103,31 @@ function decomposition_not_on_axis()
     I = [1,2,3,4,5]
     @variable(model, x[I])
     @test_throws BlockDecomposition.DecompositionNotOverAxis{Vector{Int}} @dantzig_wolfe_decomposition(model, dec, I)
+    return
+end
+
+function not_representative_of_sp()
+    model = BlockModel(MockOptimizer)
+    I = 1:5
+    @axis(J, 1:3)
+    @variable(model, x[i in I])
+    @constraint(model, cov, sum(x[i] for i in I) >= 1)
+    @constraint(model, sp1[j in J[1:2]], sum(x[i] for i in I) <= 3)
+    @constraint(model, sp2[J[3]], sum(x[i] for i in I) >= 4) # error because of A
+    
+    @dantzig_wolfe_decomposition(model, dec, J)
+    subproblemrepresentative.(x, Ref(getsubproblems(dec)[1:2])) # A
+
+    @test_throws BlockDecomposition.NotRepresentativeOfDwSp JuMP.optimize!(model)
+    return
+end
+
+function different_dw_sp_vars_in_same_dw_sp()
+    model = BlockModel(MockOptimizer)
+    @axis(I, 1:3)
+    @variable(model, x[i in I])
+    @constraint(model, sp[I[1]], x[1] + x[2] >= 1) # error
+    @dantzig_wolfe_decomposition(model, dec, I)
+    @test_throws BlockDecomposition.DwSpVarNotInGoodDwSp JuMP.optimize!(model)
     return
 end


### PR DESCRIPTION
```julia
subproblemrepresentative(x, [subproblem1, subproblem2])
```

Indicate that variable `x` will belong to many subproblem (`subproblem1` and `subproblem2`
in the example).

Variable `x` should not contain any axis id in its indices otherwise BlockDecomposition
will throw a `RepresentativeAlreadyInDwSp` error.

ping @artalvpes 