### PR TITLE
remove Base.getindex of _AxisLookup

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BlockDecomposition"
 uuid = "6cde8614-403a-11e9-12f1-c10d0f0caca0"
 authors = ["Guillaume Marques", "Vitor Nesello", "François Vanderbeck"]
-version = "1.8.0"
+version = "1.9.0"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
@@ -13,8 +13,8 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Combinatorics = "1.0.2"
-Graphs = "~1.5"
-JuMP = "~0.23, 1"
+Graphs = "~1.7"
+JuMP = "~1.2"
 MathOptInterface = "1"
 MetaGraphs = "~0.7"
 julia = "1.6"

--- a/src/axis.jl
+++ b/src/axis.jl
@@ -29,8 +29,6 @@ end
 convert(::Type{T}, i::AxisId{Name,T}) where {Name, T} = i.indice
 promote_rule(::Type{T}, ::Type{AxisId{Name,T}}) where {Name,T} = T
 
-Base.getindex(x::JuMP.Containers._AxisLookup{Dict{AxisId{Name,T},N}}, key::T) where {Name,T,N} = x.data[key]
-
 Base.hash(i::AxisId, h::UInt) = hash(i.indice, h)
 
 # Permit the access to the entry of an array using an AxisId.


### PR DESCRIPTION
`Base.getindex(x::JuMP.Containers._AxisLookup{Dict{AxisId{Name,T},N}}, key::T)` not needed anymore (or ambiguous method error).

Consequence of https://github.com/jump-dev/JuMP.jl/pull/3028