### PR TITLE
Modify compat for Graphs and MetaGraphs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,10 +13,10 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Combinatorics = "1.0.2"
-Graphs = "~1.7, 1.8"
+Graphs = "1.7"
 JuMP = "^1.2"
 MathOptInterface = "1"
-MetaGraphs = "~0.7"
+MetaGraphs = "0.7, 0.8"
 julia = "1.6"
 
 [extras]


### PR DESCRIPTION
I didn't test locally, but https://github.com/jump-dev/MathOptInterface.jl/actions/runs/18511698884/job/52871300230 tells me that this package doesn't load on Julia v1.12.